### PR TITLE
Fixed building on Windows platforms

### DIFF
--- a/src/Features/Routing/EntityInspector.cpp
+++ b/src/Features/Routing/EntityInspector.cpp
@@ -1,5 +1,6 @@
 #include "EntityInspector.hpp"
 
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <iomanip>

--- a/src/Features/Speedrun/SpeedrunTimer.cpp
+++ b/src/Features/Speedrun/SpeedrunTimer.cpp
@@ -112,7 +112,7 @@ void SpeedrunTimer::Update(const int* engineTicks, const char* engineMap)
 void SpeedrunTimer::CheckRules(const int* engineTicks)
 {
     auto action = TimerAction::DoNothing;
-    TimerRule* source;
+    TimerRule* source = NULL;
 
     for (auto& rule : this->rules) {
         if (!rule->madeAction) {

--- a/src/Utils/Memory.hpp
+++ b/src/Utils/Memory.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #ifdef _WIN32
+#define NOMINMAX
 #include <windows.h>
 #else
 #include <dlfcn.h>


### PR DESCRIPTION
Without these changes, builds on Windows (or at least with Visual Studio 2017/Win10) fail.
I'm unsure how these changes affect Linux builds, so it'd be great if someone on Linux could test it out.